### PR TITLE
feat: validate phone numbers using phonenumbers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ python-dotenv
 aiohttp
 pytest
 twilio
+phonenumbers
 quart
 hypercorn
 livekit-api


### PR DESCRIPTION
## Summary
- validate phone numbers with `phonenumbers` parsing

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'phonenumbers'; IndentationError: unexpected indent)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e4978248320a8ef254ae8a441cc